### PR TITLE
Match mailto and data schemes - fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@ module.exports = function (url) {
 		throw new TypeError('Expected a string');
 	}
 
-	return /^(?:\w+:)\/\//.test(url);
+	return /(?:^[a-z][a-z0-9+.-]*:)/.test(url);
 };

--- a/test.js
+++ b/test.js
@@ -6,6 +6,8 @@ it('should match absolute urls', function () {
 	assert(isAbsoluteUrl('http://sindresorhus.com'));
 	assert(isAbsoluteUrl('https://sindresorhus.com'));
 	assert(isAbsoluteUrl('file://sindresorhus.com'));
+	assert(isAbsoluteUrl('mailto:someone@example.com'));
+	assert(isAbsoluteUrl('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D'));
 	assert(!isAbsoluteUrl('//sindresorhus.com'));
 	assert(!isAbsoluteUrl('/foo/bar'));
 	assert(!isAbsoluteUrl('foo/bar'));


### PR DESCRIPTION
Regex taken from http://stackoverflow.com/a/31991870/182702 and modified
to disallow URIs starting with "//" (scheme-relative URIs) per #2.