### PR TITLE
Fix commas in schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,5 +12,5 @@ module.exports = url => {
 
 	// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
 	// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
-	return /^[a-z][a-z\d+-.]*:/.test(url);
+	return /^[a-z][a-z\d+.-]*:/.test(url);
 };

--- a/test.js
+++ b/test.js
@@ -14,4 +14,5 @@ test('main', t => {
 	t.false(isAbsoluteUrl('c:\\'));
 	t.false(isAbsoluteUrl('c:\\Dev\\test-broken'));
 	t.false(isAbsoluteUrl('C:\\Dev\\test-broken'));
+	t.false(isAbsoluteUrl('ht,tp://sindresorhus.com'));
 });


### PR DESCRIPTION
I noticed a bug that allows commas in the schema. The test I've added would pass before this change.

The reason for this is the "+-." is interpreted as "Any character between + and ." which includes commas.