### PR TITLE
Add parameter to check for httpOnly urls; Fixes #11

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,9 @@ isAbsoluteUrl('foo/bar');
 //=> false
 ```
 */
-declare function isAbsoluteUrl(url: string): boolean;
+declare function isAbsoluteUrl(
+	url: string,
+	{ httpOnly }?: { httpOnly?: boolean }
+): boolean;
 
 export = isAbsoluteUrl;

--- a/index.js
+++ b/index.js
@@ -12,5 +12,5 @@ module.exports = (url, {httpOnly = true} = {}) => {
 
 	// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
 	// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
-	return httpOnly ? /^https?:/.test(url) : /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+	return httpOnly ? /^https?:\/\//.test(url) : /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = url => {
+module.exports = (url, {httpOnly = true} = {}) => {
 	if (typeof url !== 'string') {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof url}\``);
 	}
@@ -12,5 +12,5 @@ module.exports = url => {
 
 	// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
 	// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
-	return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+	return httpOnly ? /^https?:/.test(url) : /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
 };

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ isAbsoluteUrl('http://sindresorhus.com/foo/bar');
 isAbsoluteUrl('ftp://sindresorhus.com/foo/bar');
 //=> false
 
-isAbsoluteUrl('ftp://sindresorhus.com/foo/bar', { httpOnly: false });
+isAbsoluteUrl('ftp://sindresorhus.com/foo/bar', {httpOnly: false});
 //=> true
 
 isAbsoluteUrl('//sindresorhus.com');

--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,26 @@ isAbsoluteUrl('//sindresorhus.com');
 isAbsoluteUrl('foo/bar');
 //=> false
 ```
-
 By default only `http` and `https` links are validated.  If you wish to check absolute URLs of protocols other than `http` (for example, `ftp:`, `mailto:`), use `isAbsoluteUrl(mayBeURL, { httpOnly: false })`.
+
+## API
+
+### isAbsoluteUrl(url, options?)
+
+#### url
+
+Type: `string`
+`url` to be validated.
+
+#### options
+
+Type: `object`
+
+##### httpOnly
+
+Type: `boolean`
+
+`true` by default, set to `false` if the url does not use `http`/`https` protocol.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 > Check if a URL is absolute
 
+By default, it checks if the URL is of the `http` or `https` protocol.
+
 
 ## Install
 
@@ -18,6 +20,15 @@ const isAbsoluteUrl = require('is-absolute-url');
 isAbsoluteUrl('https://sindresorhus.com/foo/bar');
 //=> true
 
+isAbsoluteUrl('http://sindresorhus.com/foo/bar');
+//=> true
+
+isAbsoluteUrl('ftp://sindresorhus.com/foo/bar');
+//=> false
+
+isAbsoluteUrl('ftp://sindresorhus.com/foo/bar', { httpOnly: false });
+//=> true
+
 isAbsoluteUrl('//sindresorhus.com');
 //=> false
 
@@ -25,6 +36,7 @@ isAbsoluteUrl('foo/bar');
 //=> false
 ```
 
+By default only `http` and `https` links are validated.  If you wish to check absolute URLs of protocols other than `http` (for example, `ftp:`, `mailto:`), use `isAbsoluteUrl(mayBeURL, { httpOnly: false })`.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Check if a URL is absolute
 
-By default, it checks if the URL is of the `http` or `https` protocol.
+By default, it checks if the URL uses the `http` or `https` protocol.
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ isAbsoluteUrl('//sindresorhus.com');
 isAbsoluteUrl('foo/bar');
 //=> false
 ```
+
 By default only `http` and `https` links are validated.  If you wish to check absolute URLs of protocols other than `http` (for example, `ftp:`, `mailto:`), use `isAbsoluteUrl(mayBeURL, { httpOnly: false })`.
 
 ## API
@@ -44,7 +45,8 @@ By default only `http` and `https` links are validated.  If you wish to check ab
 #### url
 
 Type: `string`
-`url` to be validated.
+
+The URL to be checked.
 
 #### options
 
@@ -52,9 +54,10 @@ Type: `object`
 
 ##### httpOnly
 
-Type: `boolean`
+Type: `boolean`\
+Default: `true`
 
-`true` by default, set to `false` if the url does not use `http`/`https` protocol.
+Set to `false` if the url does not use `http`/`https` protocol.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -4,10 +4,14 @@ import isAbsoluteUrl from '.';
 test('main', t => {
 	t.true(isAbsoluteUrl('http://sindresorhus.com'));
 	t.true(isAbsoluteUrl('https://sindresorhus.com'));
-	t.true(isAbsoluteUrl('httpS://sindresorhus.com'));
-	t.true(isAbsoluteUrl('file://sindresorhus.com'));
-	t.true(isAbsoluteUrl('mailto:someone@example.com'));
-	t.true(isAbsoluteUrl('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D'));
+	t.false(isAbsoluteUrl('httpS://sindresorhus.com'));
+	t.true(isAbsoluteUrl('httpS://sindresorhus.com', {httpOnly: false}));
+	t.false(isAbsoluteUrl('file://sindresorhus.com'));
+	t.true(isAbsoluteUrl('file://sindresorhus.com', {httpOnly: false}));
+	t.false(isAbsoluteUrl('mailto:someone@example.com'));
+	t.true(isAbsoluteUrl('mailto:someone@example.com', {httpOnly: false}));
+	t.false(isAbsoluteUrl('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D'));
+	t.true(isAbsoluteUrl('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D', {httpOnly: false}));
 	t.false(isAbsoluteUrl('//sindresorhus.com'));
 	t.false(isAbsoluteUrl('/foo/bar'));
 	t.false(isAbsoluteUrl('foo/bar'));

--- a/test.js
+++ b/test.js
@@ -3,7 +3,9 @@ import isAbsoluteUrl from '.';
 
 test('main', t => {
 	t.true(isAbsoluteUrl('http://sindresorhus.com'));
+	t.true(isAbsoluteUrl('http://sindresorhus.com', {httpOnly: true}));
 	t.true(isAbsoluteUrl('https://sindresorhus.com'));
+	t.true(isAbsoluteUrl('https://sindresorhus.com', {httpOnly: true}));
 	t.false(isAbsoluteUrl('httpS://sindresorhus.com'));
 	t.true(isAbsoluteUrl('httpS://sindresorhus.com', {httpOnly: false}));
 	t.false(isAbsoluteUrl('file://sindresorhus.com'));


### PR DESCRIPTION
Add potentially breaking change to check for `http[s]` URLs by default as requested.